### PR TITLE
Remove sql cli command

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ original [design document](https://github.com/cockroachdb/cockroach#design).
         }
 	```
 
-  1. Open up a SQL shell to read and write data in your cluster by accessing the vip endpoint. Note that if you're running DC/OS version 1.10 or greater, you could just run `dcos cockroachdb sql` instead.
+  1. Open up a SQL shell to read and write data in your cluster by accessing the vip endpoint.
 
         ```
         $ dcos node ssh --master-proxy --leader
@@ -321,9 +321,7 @@ To use a DC/OS CockroachDB cluster, all you need to do is connect to the HA-enab
 VIP hostname from the above [Discovering Endpoints](#discovering-endpoints)
 section using any PostgreSQL client driver.
 
-For example, to connect using CockroachDB's built-in SQL client, you can use the
-CLI command `dcos cockroachdb sql` if you're running DC/OS 1.10 or higher. If
-you're running an older version, you can open up a shell by running:
+For example, to connect using CockroachDB's built-in SQL client, you can open up a shell by running:
 
 ```
 dcos node ssh --master-proxy --leader
@@ -412,7 +410,7 @@ This operation will move a node to a new system and will discard the persistent 
 
 1. Run `dcos cockroachdb pods replace cockroachdb-<NUM>` to halt the current instance (if still running) and launch a new instance elsewhere.
 
-For example, let's say `cockroachdb-3`'s host system has died and `cockroachdb-3` needs to be moved. 
+For example, let's say `cockroachdb-3`'s host system has died and `cockroachdb-3` needs to be moved.
 
 1. Start `cockroachdb-3` at a new location in the cluster by running:
 

--- a/cli/dcos-cockroachdb/main.go
+++ b/cli/dcos-cockroachdb/main.go
@@ -17,7 +17,6 @@ func main() {
 
 	cli.HandleDefaultSections(app)
 
-	handleSQLSection(app)
 	handleBackupRestoreSection(app)
 	handleVersion(app)
 


### PR DESCRIPTION
- CLI `sql` command is a misleading command and will not be handle the load

- SSH into the cluster and running from the docker container clarifies to the user the mechanics more clearly