### PR TITLE
Fix upgrades/multiple-instances

### DIFF
--- a/cli/dcos-cockroachdb/main.go
+++ b/cli/dcos-cockroachdb/main.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mesosphere/dcos-commons/cli"
 	"github.com/mesosphere/dcos-commons/cli/config"
-	"gopkg.in/alecthomas/kingpin.v2"
+	"gopkg.in/alecthomas/kingpin.v3-unstable"
 )
 
 func main() {
@@ -33,7 +33,7 @@ type backupRestoreHandler struct {
 	backupDir          string
 }
 
-func (cmd *backupRestoreHandler) backup(c *kingpin.ParseContext) error {
+func (cmd *backupRestoreHandler) backup(*kingpin.Application, *kingpin.ParseElement, *kingpin.ParseContext) error {
 	fmt.Printf("Backing up database [%s] to bucket [%s]...\n", cmd.database, cmd.s3BucketName)
 
 	var dcosCmd []string
@@ -92,7 +92,7 @@ func (cmd *backupRestoreHandler) backup(c *kingpin.ParseContext) error {
 	return nil
 }
 
-func (cmd *backupRestoreHandler) restore(c *kingpin.ParseContext) error {
+func (cmd *backupRestoreHandler) restore(*kingpin.Application, *kingpin.ParseElement, *kingpin.ParseContext) error {
 	fmt.Printf("Restoring database [%s] with backup [%s] from bucket [%s]...\n", cmd.database, cmd.backupDir, cmd.s3BucketName)
 
 	var dcosCmd []string
@@ -180,7 +180,7 @@ func runDcosCommand(arg ...string) {
 	}
 }
 
-func version(c *kingpin.ParseContext) error {
+func version(*kingpin.Application, *kingpin.ParseElement, *kingpin.ParseContext) error {
 	cockroachTask := fmt.Sprintf("%s-0-node", config.ServiceName)
 	runDcosCommand("task",
 			"exec",

--- a/metrics/main.py
+++ b/metrics/main.py
@@ -17,11 +17,11 @@ class CockroachEmitter:
         statsd_host = os.getenv("STATSD_UDP_HOST")
         statsd_port = os.getenv("STATSD_UDP_PORT")
         self.conn = statsd.StatsClient(statsd_host, statsd_port)
-        self.run = False
 
     def start(self):
-        PORT_HTTP = os.getenv("PORT_HTTP")
-        url = "http://localhost:{}/_status/vars".format(PORT_HTTP)
+        framework_name = os.getenv("FRAMEWORK_NAME")
+        port_http = os.getenv("PORT_HTTP")
+        url = "http://pg.{}.l4lb.thisdcos.directory:{}/_status/vars".format(framework_name, port_http)
 
         self.run = True
         while self.run:

--- a/src/main/dist/join.sh.mustache
+++ b/src/main/dist/join.sh.mustache
@@ -12,4 +12,4 @@ $MESOS_SANDBOX/$COCKROACH_VERSION/cockroach start \
     --logtostderr \
     --http-port=$PORT_HTTP \
     --port=$PORT_PG \
-    --join="pg.cockroachdb.l4lb.thisdcos.directory:26257"
+    --join="pg.$FRAMEWORK_NAME.l4lb.thisdcos.directory:26257"

--- a/src/main/dist/svc.yml
+++ b/src/main/dist/svc.yml
@@ -31,9 +31,6 @@ pods:
           path: "cockroach-data"
           type: {{NODE_DISK_TYPE}}
           size: {{NODE_DISK}}
-      sidecar-resources:
-        cpus: {{SIDE_CPUS}}
-        memory: {{SIDE_MEM}}
     tasks:
       node-init:
         goal: RUNNING
@@ -88,16 +85,7 @@ pods:
           delay: 0
         env:
           COCKROACH_VERSION: {{COCKROACH_VERSION}}
-      metrics:
-        goal: RUNNING
-        resource-set: sidecar-resources
-        cmd: "docker run \
-              -e PORT_HTTP={{CONTAINER_HTTP_PORT}} \
-              -e STATSD_UDP_HOST=$STATSD_UDP_HOST \
-              -e STATSD_UDP_PORT=$STATSD_UDP_PORT \
-              -e PYTHONUNBUFFERED=1 \
-              --network='host' \
-              sammisthemannis/cockroach-statsd:1.1"
+          FRAMEWORK_NAME: {{FRAMEWORK_NAME}}
   admin:
     count: {{SIDE_COUNT}}
     uris:
@@ -149,16 +137,32 @@ pods:
              --host='pg.cockroachdb.l4lb.thisdcos.directory' < \
              restore/$DATABASE_NAME.sql"
         resource-set: admin-resources
+      metrics:
+        goal: RUNNING
+        resource-set: admin-resources
+        cmd: "docker run \
+              -e FRAMEWORK_NAME={{FRAMEWORK_NAME}} \
+              -e PORT_HTTP={{CONTAINER_HTTP_PORT}} \
+              -e STATSD_UDP_HOST=$STATSD_UDP_HOST \
+              -e STATSD_UDP_PORT=$STATSD_UDP_PORT \
+              -e PYTHONUNBUFFERED=1 \
+              --network='host' \
+              sammisthemannis/cockroach-statsd:v1"
 plans:
   deploy:
-    strategy: serial
+    strategy: parallel
     phases:
       node-deploy:
-        strategy: serial
+        strategy: parallel
         pod: cockroachdb
         steps:
-          - 0: [[node-init], [metrics]]
-          - default: [[node-join], [metrics]]
+          - 0: [[node-init]]
+          - default: [[node-join]]
+      metrics-deploy:
+        strategy: parallel
+        pod: admin
+        steps:
+          - default: [[metrics]]
   replace:
     strategy: parallel
     phases:
@@ -166,8 +170,8 @@ plans:
         strategy: parallel
         pod: cockroachdb
         steps:
-          - 0: [[node-init], [metrics]]
-          - default: [[node-join], [metrics]]
+          - 0: [[node-init]]
+          - default: [[node-join]]
   backup:
     strategy: serial
     phases:
@@ -183,7 +187,7 @@ plans:
         strategy: serial
         pod: admin
         steps:
-          - 0: [[restore]]
+          - default: [[restore]]
   update:
     strategy: serial
     phases:
@@ -191,5 +195,10 @@ plans:
         strategy: serial
         pod: cockroachdb
         steps:
-          - 0: [[node-init], [metrics]]
-          - default: [[node-join], [metrics]]
+          - 0: [[node-init]]
+          - default: [[node-join]]
+      metrics-deploy:
+        strategy: serial
+        pod: admin
+        steps:
+          - default: [[metrics]]

--- a/src/main/java/com/mesosphere/sdk/cockroachdb/scheduler/CockroachdbRecoveryPlanOverriderFactory.java
+++ b/src/main/java/com/mesosphere/sdk/cockroachdb/scheduler/CockroachdbRecoveryPlanOverriderFactory.java
@@ -1,10 +1,8 @@
 package com.mesosphere.sdk.cockroachdb.scheduler;
 
-import com.mesosphere.sdk.config.ConfigStore;
 import com.mesosphere.sdk.scheduler.plan.Plan;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryPlanOverrider;
 import com.mesosphere.sdk.scheduler.recovery.RecoveryPlanOverriderFactory;
-import com.mesosphere.sdk.specification.ServiceSpec;
 import com.mesosphere.sdk.state.StateStore;
 
 import java.util.Collection;
@@ -19,11 +17,9 @@ public class CockroachdbRecoveryPlanOverriderFactory implements RecoveryPlanOver
     @Override
     public RecoveryPlanOverrider create(
             StateStore stateStore,
-            ConfigStore<ServiceSpec> configStore,
             Collection<Plan> plans) {
         return new CockroachdbRecoveryPlanOverrider(
                 stateStore,
-                configStore,
                 getNodeReplacementPlan(plans));
     }
 


### PR DESCRIPTION
This PR should fix a lot of the instability when running config updates with the CockroachDB package. Some highlights:
- deploy time is down to ~30 seconds
- metrics sidecar is now a single instance in the admin pod, connecting via load-balancer
- updates are much faster / more stable with the new plan and pod configurations

*Before testing this PR, please make sure you've pulled the latest version of dcos-commons.*