### PR TITLE
Fix CNI

### DIFF
--- a/metrics/main.py
+++ b/metrics/main.py
@@ -36,6 +36,8 @@ class CockroachEmitter:
                 print("[CONNECTION ERROR] {}".format(e), file=sys.stderr)
                 print("[CONNECTION ERROR] Waiting {} seconds to retry...".format(self.CONNECTION_RETRY_INTERVAL), file=sys.stderr)
                 time.sleep(self.CONNECTION_RETRY_INTERVAL)
+            except ValueError as e:
+                print(e)
 
     def stop(self):
         self.run=False

--- a/src/main/dist/join.sh.mustache
+++ b/src/main/dist/join.sh.mustache
@@ -7,9 +7,10 @@ echo "--------------------"
 echo "Looks like there's already at least one other CockroachDB node running, connecting new node to the cluster..."
 
 # Start CockroachDB server (join existing cluster)
-$MESOS_SANDBOX/$COCKROACH_VERSION/cockroach start \
+{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach start \
     --insecure \
     --logtostderr \
-    --http-port=$PORT_HTTP \
-    --port=$PORT_PG \
-    --join="pg.$FRAMEWORK_NAME.l4lb.thisdcos.directory:26257"
+    --advertise-host={{TASK_NAME}}.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory \
+    --http-port={{PORT_HTTP}} \
+    --port={{PORT_PG}} \
+    --join=pg.{{FRAMEWORK_NAME}}.l4lb.thisdcos.directory:26257

--- a/src/main/dist/start.sh.mustache
+++ b/src/main/dist/start.sh.mustache
@@ -15,25 +15,26 @@ mkdir certs
 mkdir my-safe-directory
 
 # Create the CA key pair
-$MESOS_SANDBOX/$COCKROACH_VERSION/cockroach cert create-ca \
+{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach cert create-ca \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
 
 # Create a client key pair for the root user
-$MESOS_SANDBOX/$COCKROACH_VERSION/cockroach cert create-client root \
+{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach cert create-client root \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
 
 # Create a key pair for the first node
-$MESOS_SANDBOX/$COCKROACH_VERSION/cockroach cert create-node \
+{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach cert create-node \
     localhost \
-    $(hostname) \
+    {{TASK_NAME}}.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
 
 # Start CockroachDB server
-$MESOS_SANDBOX/$COCKROACH_VERSION/cockroach start \
+{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach start \
     --logtostderr \
     --insecure \
-    --http-port=$PORT_HTTP \
-    --port=$PORT_PG
+    --advertise-host={{TASK_NAME}}.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory \
+    --http-port={{PORT_HTTP}} \
+    --port={{PORT_PG}}

--- a/src/main/dist/svc.yml
+++ b/src/main/dist/svc.yml
@@ -85,7 +85,6 @@ pods:
           delay: 0
         env:
           COCKROACH_VERSION: {{COCKROACH_VERSION}}
-          FRAMEWORK_NAME: {{FRAMEWORK_NAME}}
   admin:
     count: {{SIDE_COUNT}}
     uris:


### PR DESCRIPTION
I recently noticed that the `node-join` tasks were unable to connect to the cluster when `virtual_networks` was set to true. Specifically, the init node seemed to think its hostname was equivalent to its container ID (snapshot of `node-init` logs):
```
I170802 17:04:56.377004 13 server/node.go:389  [n?] **** cluster f7e421d0-364e-4e56-b687-814cd3f7d72e has been created
I170802 17:04:56.377041 13 server/node.go:390  [n?] **** add additional nodes by specifying --join=dc0dda6c-ec08-4939-8bcd-042edf3a0058:26257
I170802 17:04:56.377797 13 storage/store.go:1252  [n1] [n1,s1]: failed initial metrics computation: [n1,s1]: system config not yet available
I170802 17:04:56.377856 13 server/node.go:467  [n1] initialized store [n1,s1]: {Capacity:39490912256 Available:28032184320 RangeCount:1 LeaseCount:0}
I170802 17:04:56.377890 13 server/node.go:351  [n1] node ID 1 initialized
I170802 17:04:56.378005 13 gossip/gossip.go:297  [n1] NodeDescriptor set to node_id:1 address:<network_field:"tcp" address_field:"dc0dda6c-ec08-4939-8bcd-042edf3a0058:26257" > attrs:<> locality:<> 
```

Consequently, `node-join`'s were unable to resolve the hostname that was advertised to them (snapshot of node-join logs):
```
I170802 17:20:09.566050 88 gossip/client.go:131  [n?] started gossip client to pg.cockroachdb.l4lb.thisdcos.directory:26257
I170802 17:20:16.150384 154 gossip/client.go:131  [n?] started gossip client to pg.cockroachdb.l4lb.thisdcos.directory:26257
I170802 17:20:16.151587 14 server/node.go:633  [n?] node connected via gossip and verified as part of cluster "f7e421d0-364e-4e56-b687-814cd3f7d72e"
I170802 17:20:16.151772 48 storage/stores.go:312  [n?] wrote 1 node addresses to persistent storage
I170802 17:20:16.180397 140 vendor/google.golang.org/grpc/clientconn.go:806  grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp: lookup dc0dda6c-ec08-4939-8bcd-042edf3a0058: no such host"; Reconnecting to {dc0dda6c-ec08-4939-8bcd-042edf3a0058:26257 <nil>}
I170802 17:20:17.154105 140 vendor/google.golang.org/grpc/clientconn.go:806  grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp: lookup dc0dda6c-ec08-4939-8bcd-042edf3a0058: no such host"; Reconnecting to {dc0dda6c-ec08-4939-8bcd-042edf3a0058:26257 <nil>}
I170802 17:20:17.958604 140 vendor/google.golang.org/grpc/clientconn.go:806  grpc: addrConn.resetTransport failed to create client transport: connection error: desc = "transport: dial tcp: lookup dc0dda6c-ec08-4939-8bcd-042edf3a0058: no such host"; Reconnecting to {dc0dda6c-ec08-4939-8bcd-042edf3a0058:26257 <nil>}
```

The ability to join the dcos virtual network is important because it lets confidently assume that the ports we want to use will be available (ip-per-container means this will always be true). Explicitly setting the `--advertise-host` in `cockroach start` seems to have resolved the issue.

(Sorry for sneaking an un-related metrics fix into this PR)