### PR TITLE
Clean up README, mainly by moving the build instructions down

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,5 @@
 # CockroachDB Service Guide
 
-## Build Instructions
-
-Since this framework was migrated from a branch off dcos-commons, you'll need a copy of that repository to build it
-(until the build scripts are modified appropriately). Steps to build:
-
-1. Clone [dcos-commons](https://github.com/mesosphere/dcos-commons).
-2. Add the following two lines to `dcos-commons/settings.gradle`:
-
-```
-include 'frameworks/cockroachdb'
-project(":frameworks/cockroachdb").name = "cockroachdb"
-```
-
-3. Clone this repo into `dcos-commons/frameworks/`.
-4. Use `dcos-commons/frameworks/cockroachdb/build.sh` to build.
-
 ## Table of Contents
 
 - [Overview](#overview)
@@ -56,22 +40,24 @@ project(":frameworks/cockroachdb").name = "cockroachdb"
   - [Backup Storage](#backup-storage)
   - [Enterprise Backup and Restore](#enterprise-backup-restore)
 - [Supported Versions](#supported-versions)
+- [Build Instructions](#build-instructions)
 
 <a name="overview"></a>
 # Overview
 
 DC/OS CockroachDB is an automated service that makes it easy to deploy and manage CockroachDB on [DC/OS](https://mesosphere.com/product/).
 
-CockroachDB is a distributed SQL database built on a transactional and
+CockroachDB is an open source distributed SQL database built on a transactional and
 strongly-consistent key-value store. It **scales** horizontally;
 **survives** disk, machine, rack, and even datacenter failures with
 minimal latency disruption and no manual intervention; supports
 **strongly-consistent** ACID transactions; and provides a familiar
 **SQL** API for structuring, manipulating, and querying data.
 
-For more details, check out [its website](https://www.cockroachlabs.com/),
-[FAQ](https://cockroachlabs.com/docs/frequently-asked-questions.html), or
-original [design document](https://github.com/cockroachdb/cockroach#design).
+For more details, check out [our website](https://www.cockroachlabs.com/),
+[FAQ](https://cockroachlabs.com/docs/stable/frequently-asked-questions.html),
+[architecture docs](https://www.cockroachlabs.com/docs/stable/architecture/overview.html),
+or [Github repository](https://github.com/cockroachdb/cockroach).
 
 <a name="features"></a>
 ## Features
@@ -580,3 +566,20 @@ consider contacting Cockroach Labs about an
 
 - CockroachDB: Supports versions 1.0 and above
 - DC/OS: Tested on versions 1.9 and 1.10
+
+<a name="build-instructions"></a>
+# Build Instructions
+
+Since this framework was migrated from a branch off dcos-commons, you'll need a copy of that repository to build it
+(until the build scripts are modified appropriately). Steps to build:
+
+1. Clone [dcos-commons](https://github.com/mesosphere/dcos-commons).
+2. Add the following two lines to `dcos-commons/settings.gradle`:
+
+```
+include 'frameworks/cockroachdb'
+project(":frameworks/cockroachdb").name = "cockroachdb"
+```
+
+3. Clone this repo into `dcos-commons/frameworks/`.
+4. Use `dcos-commons/frameworks/cockroachdb/build.sh` to build.


### PR DESCRIPTION
The build instructions aren't the first thing people need to see when
they open up the repo. The overview is.

I've also updated the links in the overview to point to newer
architecture docs and to the actual cockroachdb repo.