### PR TITLE
Provide the ability to configure --cache and --max-sql-memory

### DIFF
--- a/src/main/dist/join.sh.mustache
+++ b/src/main/dist/join.sh.mustache
@@ -10,6 +10,8 @@ echo "Looks like there's already at least one other CockroachDB node running, co
 {{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach start \
     --insecure \
     --logtostderr \
+    --cache={{COCKRACH_CACHE_SIZE}} \
+    --max-sql-memory={{COCKRACH_MAX_SQL_MEMORY}} \
     --advertise-host={{TASK_NAME}}.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory \
     --http-port={{PORT_HTTP}} \
     --port={{PORT_PG}} \

--- a/src/main/dist/start.sh.mustache
+++ b/src/main/dist/start.sh.mustache
@@ -35,6 +35,8 @@ mkdir my-safe-directory
 {{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach start \
     --logtostderr \
     --insecure \
+    --cache={{CACHE}} \
+    --max-sql-memory={{MAX_SQL_MEMORY}} \
     --advertise-host={{TASK_NAME}}.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory \
     --http-port={{PORT_HTTP}} \
     --port={{PORT_PG}}

--- a/tests/test_mult_instances.py
+++ b/tests/test_mult_instances.py
@@ -45,7 +45,7 @@ def test_two_service_install_with_one_task_each():
                                 "service": { "name": SERVICE_NAME },
                                 "node": { "count": task_count }
                                 }, #overrides the marathon configuration
-            package_version="1.0.1")
+            package_version="1.1.3")
         tasks.check_running(SERVICE_NAME, task_count)
 
 """ Make sure that you have at least DEFAULT_TASK_COUNT in your cluster for this test to pass
@@ -63,5 +63,5 @@ def test_two_service_install_with_DEFAULT_TASK_COUNT_tasks_each():
             additional_options={
                                 "service": { "name": SERVICE_NAME } #overrides marathon configuration
                                 },
-            package_version="1.0.1")
+            package_version="1.1.3")
         tasks.check_running(SERVICE_NAME, DEFAULT_TASK_COUNT)

--- a/universe/config.json
+++ b/universe/config.json
@@ -33,6 +33,18 @@
             "type": "string",
             "default": "1.1.3"
           },
+          "cache_size":{
+            "title": "CockroachDB cache size",
+            "description": "Cache size to be used by CockroachDB",
+            "type": "string",
+            "default": "25%"
+          },
+          "max_sql_memory":{
+            "title": "CockroachDB max SQL memory",
+            "description": "Maximum amount of memory for CockroachDB to use for processing SQL queries",
+            "type": "string",
+            "default": "25%"
+          },
           "http_port":{
             "title": "CockroachDB HTTP Port",
             "description": "Port for CockroachDB admin UI",

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -28,6 +28,8 @@
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "COCKROACH_URI": "{{resource.assets.uris.cockroach-binary}}/cockroach-v{{service.version}}.linux-amd64.tgz",
     "COCKROACH_VERSION": "cockroach-v{{service.version}}.linux-amd64",
+    "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
+    "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",
     "COCKROACH_HTTP_PORT": "{{service.http_port}}",
     "COCKROACH_PG_PORT": "{{service.pg_port}}",
     "CONTAINER_HTTP_PORT": "{{service.container_http_port}}",


### PR DESCRIPTION
Also bump the version used by a test, since these flags are only in 1.1
cockroachdb releases.