### PR TITLE
Bump version to v2.0.0

### DIFF
--- a/universe/config.json
+++ b/universe/config.json
@@ -31,7 +31,7 @@
             "title": "CockroachDB version",
             "description": "Production release version of CockroachDB",
             "type": "string",
-            "default": "1.1.7"
+            "default": "2.0.0"
           },
           "cache_size":{
             "title": "CockroachDB cache size",

--- a/universe/package.json
+++ b/universe/package.json
@@ -2,13 +2,13 @@
   "packagingVersion": "4.0",
   "minDcosReleaseVersion": "1.9",
   "name": "cockroachdb",
-  "version": "1.1.7-1.1.7",
+  "version": "2.0.0-2.0.0",
   "maintainer": "support@cockroachlabs.com",
   "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/cockroachdb/dcos-cockroachdb-service The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
   "selected": false,
   "framework": true,
   "tags": ["cockroachdb", "sql", "database"],
   "preInstallNotes": "This DC/OS Service is currently in preview. There may be bugs, incomplete features, incorrect documentation, or other discrepancies. Preview packages should never be used in production! For a replicated cluster, please use at least 3 nodes to ensure availability with 1 CPU and 2 GB of RAM per node.",
-  "postInstallNotes": "CockroachDB is being installed!\n\n\tDocumentation: https://www.cockroachlabs.com/docs\n\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\n\tRelease Notes: https://www.cockroachlabs.com/docs/releases/v1.1.7.html",
+  "postInstallNotes": "CockroachDB is being installed!\n\n\tDocumentation: https://www.cockroachlabs.com/docs\n\tIssues: contact https://www.cockroachlabs.com/docs/support-resources.html\n\tRelease Notes: https://www.cockroachlabs.com/docs/releases/v2.0.0.html",
   "postUninstallNotes": "CockroachDB has been uninstalled."
 }


### PR DESCRIPTION
Done early so that we can have the framework published for the meetup tomorrow night. Upstream PR at https://github.com/cockroachdb/docs/pull/2823