### PR TITLE
Fix flapping tasks caused by missing COCKROACH_VERSION env var

### DIFF
--- a/src/main/dist/start.sh.mustache
+++ b/src/main/dist/start.sh.mustache
@@ -15,24 +15,24 @@ mkdir certs
 mkdir my-safe-directory
 
 # Create the CA key pair
-{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach cert create-ca \
+{{MESOS_SANDBOX}}/{{COCKROACH_DIR}}/cockroach cert create-ca \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
 
 # Create a client key pair for the root user
-{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach cert create-client root \
+{{MESOS_SANDBOX}}/{{COCKROACH_DIR}}/cockroach cert create-client root \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
 
 # Create a key pair for the first node
-{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach cert create-node \
+{{MESOS_SANDBOX}}/{{COCKROACH_DIR}}/cockroach cert create-node \
     localhost \
     {{TASK_NAME}}.{{FRAMEWORK_NAME}}.autoip.dcos.thisdcos.directory \
     --certs-dir=certs \
     --ca-key=my-safe-directory/ca.key
 
 # Start CockroachDB server
-{{MESOS_SANDBOX}}/{{COCKROACH_VERSION}}/cockroach start \
+{{MESOS_SANDBOX}}/{{COCKROACH_DIR}}/cockroach start \
     --logtostderr \
     --insecure \
     --cache={{COCKROACH_CACHE_SIZE}} \

--- a/src/main/dist/svc.yml
+++ b/src/main/dist/svc.yml
@@ -44,7 +44,7 @@ pods:
             dest: "join.sh"
         cmd: "./bootstrap && \
               chmod +x $MESOS_SANDBOX/start.sh && \
-              ln -s $MESOS_SANDBOX/{{COCKROACH_VERSION}}/cockroach cockroach && \
+              ln -s $MESOS_SANDBOX/{{COCKROACH_DIR}}/cockroach cockroach && \
               $MESOS_SANDBOX/start.sh"
         readiness-check:
           cmd: "curl -sf localhost:$PORT_HTTP/_admin/v1/health >/dev/null 2>/dev/null"
@@ -59,7 +59,7 @@ pods:
           timeout: 10
           delay: 0
         env:
-          COCKROACH_VERSION: {{COCKROACH_VERSION}}
+          COCKROACH_DIR: {{COCKROACH_DIR}}
           COCKROACH_CACHE_SIZE: {{COCKROACH_CACHE_SIZE}}
           COCKROACH_MAX_SQL_MEMORY: {{COCKROACH_MAX_SQL_MEMORY}}
           COCKROACH_CHANNEL: mesosphere-dcos
@@ -72,7 +72,7 @@ pods:
             dest: "join.sh"
         cmd: "./bootstrap && \
               chmod +x $MESOS_SANDBOX/join.sh && \
-              ln -s $MESOS_SANDBOX/{{COCKROACH_VERSION}}/cockroach cockroach && \
+              ln -s $MESOS_SANDBOX/{{COCKROACH_DIR}}/cockroach cockroach && \
               $MESOS_SANDBOX/join.sh"
         readiness-check:
           cmd: "curl -sf localhost:$PORT_HTTP/_admin/v1/health >/dev/null 2>/dev/null"
@@ -87,7 +87,7 @@ pods:
           timeout: 10
           delay: 0
         env:
-          COCKROACH_VERSION: {{COCKROACH_VERSION}}
+          COCKROACH_DIR: {{COCKROACH_DIR}}
           COCKROACH_CACHE_SIZE: {{COCKROACH_CACHE_SIZE}}
           COCKROACH_MAX_SQL_MEMORY: {{COCKROACH_MAX_SQL_MEMORY}}
           COCKROACH_CHANNEL: mesosphere-dcos
@@ -115,7 +115,7 @@ pods:
               chmod +x $MESOS_SANDBOX/aws.sh && \
               mkdir backup && \
               touch backup/$DATABASE_NAME.sql && \
-              $MESOS_SANDBOX/{{COCKROACH_VERSION}}/cockroach dump $DATABASE_NAME --insecure \
+              $MESOS_SANDBOX/{{COCKROACH_DIR}}/cockroach dump $DATABASE_NAME --insecure \
               --host='pg.cockroachdb.l4lb.thisdcos.directory' > \
               backup/$DATABASE_NAME.sql && \
               $MESOS_SANDBOX/aws.sh s3 cp \
@@ -134,10 +134,10 @@ pods:
              $MESOS_SANDBOX/aws.sh s3 cp \
              s3://$S3_BUCKET_NAME/$S3_DIR_PATH/$BACKUP_DIR/$DATABASE_NAME.sql \
              restore/ && \
-             $MESOS_SANDBOX/{{COCKROACH_VERSION}}/cockroach sql --insecure \
+             $MESOS_SANDBOX/{{COCKROACH_DIR}}/cockroach sql --insecure \
              --execute=\"CREATE DATABASE IF NOT EXISTS $DATABASE_NAME\" \
              --host='pg.cockroachdb.l4lb.thisdcos.directory' && \
-             $MESOS_SANDBOX/{{COCKROACH_VERSION}}/cockroach sql \
+             $MESOS_SANDBOX/{{COCKROACH_DIR}}/cockroach sql \
              --database=$DATABASE_NAME --insecure \
              --host='pg.cockroachdb.l4lb.thisdcos.directory' < \
              restore/$DATABASE_NAME.sql"

--- a/universe/marathon.json.mustache
+++ b/universe/marathon.json.mustache
@@ -27,6 +27,7 @@
     "FRAMEWORK_USER": "{{service.user}}",
     "FRAMEWORK_PRINCIPAL": "{{service.service_account}}",
     "COCKROACH_URI": "{{resource.assets.uris.cockroach-tgz}}",
+    "COCKROACH_DIR": "cockroach-v2.0.1.linux-amd64",
     "COCKROACH_CACHE_SIZE": "{{service.cache_size}}",
     "COCKROACH_MAX_SQL_MEMORY": "{{service.max_sql_memory}}",
     "COCKROACH_HTTP_PORT": "{{service.http_port}}",

--- a/universe/package.json
+++ b/universe/package.json
@@ -2,7 +2,7 @@
   "packagingVersion": "4.0",
   "minDcosReleaseVersion": "1.9",
   "name": "cockroachdb",
-  "version": "2.0.0-2.0.1",
+  "version": "2.0.1-2.0.1",
   "maintainer": "support@cockroachlabs.com",
   "description": "CockroachDB is a distributed relational database that is scalable, survivable, and strongly consistent. Service Guide is available at: https://github.com/cockroachdb/dcos-cockroachdb-service The source code for CockroachDB Enterprise is packaged in the same binary as CockroachDB Core.\n\n\tCustomers interested in the CockroachDB Enterprise license should contact https://www.cockroachlabs.com/pricing/sales/",
   "selected": false,


### PR DESCRIPTION
Fixes my mistakes from #61

This means we have yet another place with the version hard-coded, but
I'd rather deal with updating an extra place once in a while than
spending hours more trying to figure out a better way to do it when all
the upstream examples do this.