### PR TITLE
Fix metric gathering url and port

### DIFF
--- a/metrics/main.py
+++ b/metrics/main.py
@@ -21,7 +21,7 @@ class CockroachEmitter:
     def start(self):
         framework_name = os.getenv("FRAMEWORK_NAME")
         port_http = os.getenv("PORT_HTTP")
-        url = "http://pg.{}.l4lb.thisdcos.directory:{}/_status/vars".format(framework_name, port_http)
+        url = "http://http.{}.l4lb.thisdcos.directory:{}/_status/vars".format(framework_name.replace("/",""), port_http)
 
         self.run = True
         while self.run:

--- a/src/main/dist/svc.yml
+++ b/src/main/dist/svc.yml
@@ -153,7 +153,7 @@ pods:
         goal: RUNNING
         cmd: "docker run \
               -e FRAMEWORK_NAME={{FRAMEWORK_NAME}} \
-              -e PORT_HTTP={{CONTAINER_HTTP_PORT}} \
+              -e PORT_HTTP={{COCKROACH_HTTP_PORT}} \
               -e STATSD_UDP_HOST=$STATSD_UDP_HOST \
               -e STATSD_UDP_PORT=$STATSD_UDP_PORT \
               -e PYTHONUNBUFFERED=1 \


### PR DESCRIPTION
Hello.

Currently, metric system isn't working like this:
```
CONNECTION ERROR] HTTPConnectionPool(host='pg.cockroachdb.l4lb.thisdcos.directory', port=8123): Max retries exceeded with url: /_status/vars (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f0c2db94978>: Failed to establish a new connection: [Errno 111] Connection refused',))
[CONNECTION ERROR] Waiting 60 seconds to retry...
```

I think https://github.com/cockroachdb/dcos-cockroachdb-service/commit/04e30997899daaef555b633a022272c573e5acfc and https://github.com/cockroachdb/dcos-cockroachdb-service/commit/e2136823bab0573923e27329692230568734878c commits set the wrong `VIP` prefix and `PORT_HTTP`.

This PR fix the url and the port, and use `framework_name.replace("/","")` for nested service ID like this: `test/cockroachdb`.

After this PR, I'll send another PR for `join.sh.mustache` and `init.sh.mustache` which contains `FRAMEWORK_NAME` env variable too. The nested service is also broken by these uses.

Thank you.